### PR TITLE
Fixed infinite ammo triggers

### DIFF
--- a/BSPConvertLib/Source/EntityConverter.cs
+++ b/BSPConvertLib/Source/EntityConverter.cs
@@ -767,6 +767,9 @@ namespace BSPConvertLib
 			if (!ammoEnt.TryGetValue("count", out var count) || count == "0")
 				count = GetDefaultAmmoCount(ammoEnt.ClassName);
 
+			if (float.Parse(count) < 0)
+				ammoOutput = ammoOutput.Replace("Add", "Set"); // Applies infinite ammo when count is set to a negative value to mimic q3 behaviour
+
 			var connection = new Entity.EntityConnection()
 			{
 				name = "OnStartTouch",
@@ -776,8 +779,6 @@ namespace BSPConvertLib
 				delay = 0.01f, //hack to make giving ammo happen after setting ammo
 				fireOnce = -1
 			};
-			if (float.Parse(count) < 0)
-				connection.action = connection.action.Replace("Add", "Set"); // Applies infinite ammo when count is set to a negative value to mimic q3 behaviour
 
 			trigger.connections.Add(connection);
 		}

--- a/BSPConvertLib/Source/EntityConverter.cs
+++ b/BSPConvertLib/Source/EntityConverter.cs
@@ -779,7 +779,6 @@ namespace BSPConvertLib
 				delay = 0.01f, //hack to make giving ammo happen after setting ammo
 				fireOnce = -1
 			};
-
 			trigger.connections.Add(connection);
 		}
 

--- a/BSPConvertLib/Source/EntityConverter.cs
+++ b/BSPConvertLib/Source/EntityConverter.cs
@@ -776,6 +776,9 @@ namespace BSPConvertLib
 				delay = 0.01f, //hack to make giving ammo happen after setting ammo
 				fireOnce = -1
 			};
+			if (float.Parse(count) < 0)
+				connection.action = connection.action.Replace("Add", "Set"); // Applies infinite ammo when count is set to a negative value to mimic q3 behaviour
+
 			trigger.connections.Add(connection);
 		}
 


### PR DESCRIPTION
In Q3, infinite ammo is applied by a target_give pointing to an ammo entity with a negative value set as the ammo count. This mimics that behaviour.