### PR TITLE
Added option to ignore patches with tool textures

### DIFF
--- a/BSPConvert.Cmd/Program.cs
+++ b/BSPConvert.Cmd/Program.cs
@@ -11,6 +11,9 @@ namespace BSPConvert.Cmd
 			[Option("nopak", Required = false, HelpText = "Export materials into folders instead of embedding them in the BSP.")]
 			public bool NoPak { get; set; }
 
+			[Option("notooldisps", Required = false, HelpText = "Skip converting patches with tool textures to displacements.")]
+			public bool NoToolDisplacements { get; set; }
+
 			[Option("subdiv", Required = false, Default = 4, HelpText = "Displacement subdivisions [2-4].")]
 			public int DisplacementPower { get; set; }
 
@@ -61,6 +64,7 @@ namespace BSPConvert.Cmd
 				var converterOptions = new BSPConverterOptions()
 				{
 					noPak = options.NoPak,
+					noToolDisplacements = options.NoToolDisplacements,
 					DisplacementPower = options.DisplacementPower,
 					minDamageToConvertTrigger = options.MinDamageToConvertTrigger,
 					ignoreZones = options.IgnoreZones,

--- a/BSPConvert.Lib/Source/BSPConverter.cs
+++ b/BSPConvert.Lib/Source/BSPConverter.cs
@@ -48,6 +48,7 @@ namespace BSPConvert.Lib
 	public class BSPConverterOptions
 	{
 		public bool noPak;
+		public bool noToolDisplacements;
 		private int displacementPower;
 		public int DisplacementPower
 		{
@@ -1055,6 +1056,9 @@ namespace BSPConvert.Lib
 
 		private void CreatePatchDisplacement(int sFaceIndex, Vertex[] faceVerts, int patchWidth, int patchStartVertex, Face qFace)
 		{
+			if (options.noToolDisplacements && qFace.Texture.Name.StartsWith("tools/"))
+				return;
+
 			var data = new byte[Displacement.GetStructLength(sourceBsp.MapType)];
 			var displacement = new Displacement(data, sourceBsp.Displacements);
 


### PR DESCRIPTION
Some q3 maps have one-way patches with a clip texture over the start zone to prevent players reentering the spawn. These convert to solid brushes in source and trap the player in, so an option to ignore them is useful in such cases.