### PR TITLE
Added option to smooth out shadows

### DIFF
--- a/BSPConvert.Cmd/Program.cs
+++ b/BSPConvert.Cmd/Program.cs
@@ -23,6 +23,9 @@ namespace BSPConvert.Cmd
 			[Option("nozones", Required = false, HelpText = "Ignore timer zone triggers.")]
 			public bool IgnoreZones { get; set; }
 
+			[Option("smoothshadows", Required = false, Default = 1, HelpText = "Increase color range for smoother shadows. Higher values may negatively impact brighter areas [1-16].")]
+			public int SmoothShadows { get; set; }
+
 			//[Option("oldbsp", Required = false, HelpText = "Use BSP version 20 (HL2 / CS:S).")]
 			//public bool OldBSP { get; set; }
 
@@ -56,6 +59,9 @@ namespace BSPConvert.Cmd
 			if (options.DisplacementPower < 2 || options.DisplacementPower > 4)
 				throw new ArgumentOutOfRangeException("Displacement power must be between 2 and 4.");
 
+			if (options.SmoothShadows < 1 || options.SmoothShadows > 16)
+				throw new ArgumentOutOfRangeException("Smooth shadow multiplier must be between 1 and 16.");
+
 			if (options.OutputDirectory == null)
 				options.OutputDirectory = Path.GetDirectoryName(options.InputFiles.First());
 
@@ -68,6 +74,7 @@ namespace BSPConvert.Cmd
 					DisplacementPower = options.DisplacementPower,
 					minDamageToConvertTrigger = options.MinDamageToConvertTrigger,
 					ignoreZones = options.IgnoreZones,
+					smoothShadows = options.SmoothShadows,
 					//oldBSP = options.OldBSP,
 					prefix = options.Prefix,
 					inputFile = inputEntry,

--- a/BSPConvert.Lib/Source/BSPConverter.cs
+++ b/BSPConvert.Lib/Source/BSPConverter.cs
@@ -57,6 +57,7 @@ namespace BSPConvert.Lib
 		}
 		public int minDamageToConvertTrigger;
 		public bool ignoreZones;
+		public int smoothShadows;
 		public bool oldBSP;
 		public string prefix;
 		public string inputFile;
@@ -220,7 +221,7 @@ namespace BSPConvert.Lib
 
 		private void ConvertMaterials()
 		{
-			var materialConverter = new MaterialConverter(contentManager.ContentDir, shaderDict);
+			var materialConverter = new MaterialConverter(contentManager.ContentDir, shaderDict, options.smoothShadows);
 			foreach (var texture in quakeBsp.Textures)
 				materialConverter.Convert(texture.Name);
 		}
@@ -1477,7 +1478,8 @@ namespace BSPConvert.Lib
 						var color = ColorUtil.ConvertQ3LightmapToColorRGBExp32(
 							qLightmapData[q3LightmapOffset + index * 3 + 0],
 							qLightmapData[q3LightmapOffset + index * 3 + 1],
-							qLightmapData[q3LightmapOffset + index * 3 + 2]);
+							qLightmapData[q3LightmapOffset + index * 3 + 2],
+							4 * options.smoothShadows); // internal lightmaps need * 4 brightness, darker than external lightmaps.
 
 						lmColors.Add(color);
 					}
@@ -1542,7 +1544,8 @@ namespace BSPConvert.Lib
 						var color = ColorUtil.ConvertQ3LightmapToColorRGBExp32(
 							lmData.data[index * 3 + 0],
 							lmData.data[index * 3 + 1],
-							lmData.data[index * 3 + 2]);
+							lmData.data[index * 3 + 2],
+							options.smoothShadows);
 
 						lmColors.Add(color);
 					}

--- a/BSPConvert.Lib/Source/MaterialConverter.cs
+++ b/BSPConvert.Lib/Source/MaterialConverter.cs
@@ -9,6 +9,7 @@ namespace BSPConvert.Lib
 {
 	public class MaterialConverter
 	{
+		private int smoothShadows;
 		private string pk3Dir;
 		private Dictionary<string, Shader> shaderDict;
 		private Dictionary<string, string> pk3ImageDict;
@@ -24,8 +25,9 @@ namespace BSPConvert.Lib
 			"up"
 		};
 
-		public MaterialConverter(string pk3Dir, Dictionary<string, Shader> shaderDict)
+		public MaterialConverter(string pk3Dir, Dictionary<string, Shader> shaderDict, int smoothShadows)
 		{
+			this.smoothShadows = smoothShadows;
 			this.pk3Dir = pk3Dir;
 			this.shaderDict = shaderDict;
 			pk3ImageDict = GetImageLookupDictionary(pk3Dir);
@@ -201,11 +203,12 @@ namespace BSPConvert.Lib
 
 		private string GenerateUnlitVMT(Shader shader)
 		{
+			var lightmapped = false;
 			var sb = new StringBuilder();
 			sb.AppendLine("UnlitGeneric");
 			sb.AppendLine("{");
 
-			AppendShaderParameters(sb, shader);
+			AppendShaderParameters(sb, shader, lightmapped);
 
 			sb.AppendLine("}");
 
@@ -214,19 +217,21 @@ namespace BSPConvert.Lib
 
 		private string GenerateLitVMT(Shader shader)
 		{
+			var lightmapped = true;
 			var sb = new StringBuilder();
 			sb.AppendLine("LightmappedGeneric");
 			sb.AppendLine("{");
 
-			AppendShaderParameters(sb, shader);
+			AppendShaderParameters(sb, shader, lightmapped);
 
 			sb.AppendLine("}");
 
 			return sb.ToString();
 		}
 
-		private void AppendShaderParameters(StringBuilder sb, Shader shader)
+		private void AppendShaderParameters(StringBuilder sb, Shader shader, bool lightmapped)
 		{
+			var shadowCorrection = Math.Round(255f / smoothShadows);
 			var stages = shader.GetImageStages();
 			var textureStage = stages.FirstOrDefault(x => x.bundles[0].tcGen != TexCoordGen.TCGEN_ENVIRONMENT_MAPPED && x.bundles[0].tcGen != TexCoordGen.TCGEN_LIGHTMAP);
 			if (textureStage != null)
@@ -237,9 +242,23 @@ namespace BSPConvert.Lib
 				if (textureStage.rgbGen.HasFlag(ColorGen.CGEN_CONST))
 				{
 					var color = textureStage.constantColor;
-					var colorStr = $"{color[0]} {color[1]} {color[2]}";
-					sb.AppendLine("\t$color \"{" + colorStr + "}\"");
+					var r = Math.Round(255 * Math.Pow((float)color[0] / 255, 2.2), 2); // gamma correct rgb values
+					var g = Math.Round(255 * Math.Pow((float)color[1] / 255, 2.2), 2);
+					var b = Math.Round(255 * Math.Pow((float)color[2] / 255, 2.2), 2);
+
+					if (lightmapped)
+					{
+						var colorStr = $"{Math.Round(r / smoothShadows, 2)} {Math.Round(g / smoothShadows, 2)} {Math.Round(b / smoothShadows, 2)}"; // apply custom brightness settings on lightmapped textures
+						sb.AppendLine("\t$color2 \"{" + colorStr + "}\"");
+					}
+					else
+					{
+						var colorStr = $"{r} {g} {b}";
+						sb.AppendLine("\t$color2 \"{" + colorStr + "}\"");
+					}
 				}
+				else if (lightmapped && smoothShadows > 1)
+					sb.AppendLine($$"""    $color2 "{ {{shadowCorrection}} {{shadowCorrection}} {{shadowCorrection}} }" """);
 
 				if (textureStage.alphaGen.HasFlag(AlphaGen.AGEN_CONST))
 				{
@@ -463,7 +482,18 @@ namespace BSPConvert.Lib
 
 		private string GenerateDefaultLitVMT(string texture)
 		{
-			return $$"""
+			var shadowCorrection = Math.Round(255f / smoothShadows);
+
+			if (smoothShadows > 1) // gamma correct textures to match modified lightmap brightness
+				return $$"""
+				LightmappedGeneric
+				{
+					$basetexture "{{texture}}"
+					$color2 "{ {{shadowCorrection}} {{shadowCorrection}} {{shadowCorrection}} }" 
+				}
+				""";
+			else
+				return $$"""
 				LightmappedGeneric
 				{
 					$basetexture "{{texture}}"

--- a/BSPConvert.Lib/Source/MaterialConverter.cs
+++ b/BSPConvert.Lib/Source/MaterialConverter.cs
@@ -203,12 +203,11 @@ namespace BSPConvert.Lib
 
 		private string GenerateUnlitVMT(Shader shader)
 		{
-			var lightmapped = false;
 			var sb = new StringBuilder();
 			sb.AppendLine("UnlitGeneric");
 			sb.AppendLine("{");
 
-			AppendShaderParameters(sb, shader, lightmapped);
+			AppendShaderParameters(sb, shader, false);
 
 			sb.AppendLine("}");
 
@@ -217,12 +216,11 @@ namespace BSPConvert.Lib
 
 		private string GenerateLitVMT(Shader shader)
 		{
-			var lightmapped = true;
 			var sb = new StringBuilder();
 			sb.AppendLine("LightmappedGeneric");
 			sb.AppendLine("{");
 
-			AppendShaderParameters(sb, shader, lightmapped);
+			AppendShaderParameters(sb, shader, true);
 
 			sb.AppendLine("}");
 
@@ -231,7 +229,6 @@ namespace BSPConvert.Lib
 
 		private void AppendShaderParameters(StringBuilder sb, Shader shader, bool lightmapped)
 		{
-			var shadowCorrection = Math.Round(255f / smoothShadows);
 			var stages = shader.GetImageStages();
 			var textureStage = stages.FirstOrDefault(x => x.bundles[0].tcGen != TexCoordGen.TCGEN_ENVIRONMENT_MAPPED && x.bundles[0].tcGen != TexCoordGen.TCGEN_LIGHTMAP);
 			if (textureStage != null)
@@ -242,23 +239,20 @@ namespace BSPConvert.Lib
 				if (textureStage.rgbGen.HasFlag(ColorGen.CGEN_CONST))
 				{
 					var color = textureStage.constantColor;
-					var r = Math.Round(255 * Math.Pow((float)color[0] / 255, 2.2), 2); // gamma correct rgb values
-					var g = Math.Round(255 * Math.Pow((float)color[1] / 255, 2.2), 2);
-					var b = Math.Round(255 * Math.Pow((float)color[2] / 255, 2.2), 2);
 
-					if (lightmapped)
-					{
-						var colorStr = $"{Math.Round(r / smoothShadows, 2)} {Math.Round(g / smoothShadows, 2)} {Math.Round(b / smoothShadows, 2)}"; // apply custom brightness settings on lightmapped textures
-						sb.AppendLine("\t$color2 \"{" + colorStr + "}\"");
-					}
-					else
-					{
-						var colorStr = $"{r} {g} {b}";
-						sb.AppendLine("\t$color2 \"{" + colorStr + "}\"");
-					}
+					var r = ColorUtil.GammaToLinear(color[0]); // gamma correct rgb values
+					var g = ColorUtil.GammaToLinear(color[1]);
+					var b = ColorUtil.GammaToLinear(color[2]);
+
+					var colorStr = lightmapped ? $"{Math.Round(r / smoothShadows, 2)} {Math.Round(g / smoothShadows, 2)} {Math.Round(b / smoothShadows, 2)}" : $"{r} {g} {b}";
+
+					sb.AppendLine("\t$color2 \"{" + colorStr + "}\"");
 				}
 				else if (lightmapped && smoothShadows > 1)
-					sb.AppendLine($$"""    $color2 "{ {{shadowCorrection}} {{shadowCorrection}} {{shadowCorrection}} }" """);
+				{
+					var shadowCorrection = Math.Round(255f / smoothShadows);
+					sb.AppendLine($$"""    $color2 "{ {{shadowCorrection}} {{shadowCorrection}} {{shadowCorrection}} }" """); 
+				}
 
 				if (textureStage.alphaGen.HasFlag(AlphaGen.AGEN_CONST))
 				{
@@ -482,9 +476,10 @@ namespace BSPConvert.Lib
 
 		private string GenerateDefaultLitVMT(string texture)
 		{
-			var shadowCorrection = Math.Round(255f / smoothShadows);
-
 			if (smoothShadows > 1) // gamma correct textures to match modified lightmap brightness
+			{
+				var shadowCorrection = Math.Round(255f / smoothShadows);
+
 				return $$"""
 				LightmappedGeneric
 				{
@@ -492,13 +487,16 @@ namespace BSPConvert.Lib
 					$color2 "{ {{shadowCorrection}} {{shadowCorrection}} {{shadowCorrection}} }" 
 				}
 				""";
+			}
 			else
+			{
 				return $$"""
 				LightmappedGeneric
 				{
 					$basetexture "{{texture}}"
 				}
 				""";
+			}
 		}
 	}
 }

--- a/BSPConvert.Lib/Source/Utilities/ColorUtil.cs
+++ b/BSPConvert.Lib/Source/Utilities/ColorUtil.cs
@@ -2,13 +2,13 @@
 {
 	public static class ColorUtil
 	{
-		public static ColorRGBExp32 ConvertQ3LightmapToColorRGBExp32(byte r, byte g, byte b, float multi)
+		public static ColorRGBExp32 ConvertQ3LightmapToColorRGBExp32(byte r, byte g, byte b, float brightness)
 		{
 			var color = new ColorRGBExp32();
 
-			var rf = GammaToLinear(r) * multi; // brightness multiplier
-			var gf = GammaToLinear(g) * multi;
-			var bf = GammaToLinear(b) * multi;
+			var rf = GammaToLinear(r) * brightness;
+			var gf = GammaToLinear(g) * brightness;
+			var bf = GammaToLinear(b) * brightness;
 
 			var max = Math.Max(rf, Math.Max(gf, bf));
 			var exp = CalcExponent(max);
@@ -24,7 +24,7 @@
 			return color;
 		}
 
-		private static float GammaToLinear(byte gamma)
+		public static float GammaToLinear(byte gamma)
 		{
 			return (float)(255.0 * Math.Pow(gamma / 255.0, 2.2));
 		}

--- a/BSPConvert.Lib/Source/Utilities/ColorUtil.cs
+++ b/BSPConvert.Lib/Source/Utilities/ColorUtil.cs
@@ -2,13 +2,13 @@
 {
 	public static class ColorUtil
 	{
-		public static ColorRGBExp32 ConvertQ3LightmapToColorRGBExp32(byte r, byte g, byte b)
+		public static ColorRGBExp32 ConvertQ3LightmapToColorRGBExp32(byte r, byte g, byte b, float multi)
 		{
 			var color = new ColorRGBExp32();
 
-			var rf = GammaToLinear(r) * 4f; // Multiply by 4 since Source expects lightmap values in 0-4 range
-			var gf = GammaToLinear(g) * 4f;
-			var bf = GammaToLinear(b) * 4f;
+			var rf = GammaToLinear(r) * multi; // brightness multiplier
+			var gf = GammaToLinear(g) * multi;
+			var bf = GammaToLinear(b) * multi;
 
 			var max = Math.Max(rf, Math.Max(gf, bf));
 			var exp = CalcExponent(max);


### PR DESCRIPTION
Dark shadows look terrible when converted, so I've added an option to fix that. Changing the value of ``smoothshadows`` multiplies the lightmap brightness by that number, and makes every lightmapped texture darker by the same amount to compensate for the now brighter shadows.

Before
![chaos_WOy3TO3SwD](https://github.com/user-attachments/assets/1a600a5e-de8f-4104-9906-157ee49c02e3)

After
![chaos_fr2r4tl6k7](https://github.com/user-attachments/assets/45c898f9-a20d-4a89-bdab-0133684f36fd)
