### PR TITLE
Bump dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,5 @@ FodyWeavers.xsd
 
 # JetBrains Rider
 *.sln.iml
+
+.idea/

--- a/BSPConvert.Lib/BSPConvert.Lib.csproj
+++ b/BSPConvert.Lib/BSPConvert.Lib.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpCompress" Version="0.32.2" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="SharpCompress" Version="0.39.0" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ImageSharp has a High CVE so upgrading to 3.1.7, did SharpCompress as well. Not doing the Test package stuff, those libraries are out of date by major versions and don't know them.