### PR TITLE
Improvements to powerup count conversion

### DIFF
--- a/BSPConvert.Lib/Source/EntityConverter.cs
+++ b/BSPConvert.Lib/Source/EntityConverter.cs
@@ -1183,10 +1183,12 @@ namespace BSPConvert.Lib
 
 		private string ConvertPowerupCount(string count)
 		{
-			if (!string.IsNullOrEmpty(count) && count != "0")
+			if (float.TryParse(count, out var duration) && duration != 0 && duration < 99)
 				return count;
-
-			return "30";
+			else if (duration >= 99)
+				return "-1";
+			else
+				return "30";
 		}
 
 		private void ConvertTeleportTrigger(Entity trigger, Entity targetTele)


### PR DESCRIPTION
95% of defrag maps are less than a minute long, so setting count to infinite when over >99 seconds makes sense. Plus 3+ digit numbers look really gross counting down on the HUD.