### PR TITLE
Changed button output from "OnPressed" to "OnIn" to match Q3 behaviour

### DIFF
--- a/BSPConvert.Lib/Source/EntityConverter.cs
+++ b/BSPConvert.Lib/Source/EntityConverter.cs
@@ -313,7 +313,7 @@ namespace BSPConvert.Lib
 			SetButtonFlags(button);
 
 			var delay = 0f;
-			ConvertEntityTargetsRecursive(button, button, "OnPressed", delay, new HashSet<Entity>());
+			ConvertEntityTargetsRecursive(button, button, "OnIn", delay, new HashSet<Entity>());
 
 			if (string.IsNullOrEmpty(button["speed"]))
 				button["speed"] = "40";


### PR DESCRIPTION
buttons only activate when fully retracted in Q3