### PR TITLE
Keep trigger_hurt for respawning players

### DIFF
--- a/BSPConvert.Cmd/Program.cs
+++ b/BSPConvert.Cmd/Program.cs
@@ -17,8 +17,8 @@ namespace BSPConvert.Cmd
 			[Option("subdiv", Required = false, Default = 4, HelpText = "Displacement subdivisions [2-4].")]
 			public int DisplacementPower { get; set; }
 
-			[Option("mindmg", Required = false, Default = 50, HelpText = "Minimum damage to convert trigger_hurt into trigger_teleport.")]
-			public int MinDamageToConvertTrigger { get; set; }
+			[Option("mindmg", Required = false, Default = 50, HelpText = "Minimum damage for trigger_hurt to respawn player.")]
+			public int MinDamageToRespawnPlayer { get; set; }
 
 			[Option("nozones", Required = false, HelpText = "Ignore timer zone triggers.")]
 			public bool IgnoreZones { get; set; }
@@ -68,7 +68,7 @@ namespace BSPConvert.Cmd
 					noPak = options.NoPak,
 					noToolDisplacements = options.NoToolDisplacements,
 					DisplacementPower = options.DisplacementPower,
-					minDamageToConvertTrigger = options.MinDamageToConvertTrigger,
+					minDamageToRespawnPlayer = options.MinDamageToRespawnPlayer,
 					ignoreZones = options.IgnoreZones,
 					//oldBSP = options.OldBSP,
 					prefix = options.Prefix,

--- a/BSPConvert.Lib/Source/BSPConverter.cs
+++ b/BSPConvert.Lib/Source/BSPConverter.cs
@@ -56,7 +56,7 @@ namespace BSPConvert.Lib
 			get { return displacementPower; }
 			set { displacementPower = Math.Clamp(value, 2, 4); }
 		}
-		public int minDamageToConvertTrigger;
+		public int minDamageToRespawnPlayer;
 		public bool ignoreZones;
 		public bool oldBSP;
 		public string prefix;
@@ -272,7 +272,7 @@ namespace BSPConvert.Lib
 
 		private void ConvertEntities()
 		{
-			var converter = new EntityConverter(quakeBsp.Models, quakeBsp.Entities, sourceBsp.Entities, shaderDict, options.minDamageToConvertTrigger, options.ignoreZones);
+			var converter = new EntityConverter(quakeBsp.Models, quakeBsp.Entities, sourceBsp.Entities, shaderDict, options.minDamageToRespawnPlayer, options.ignoreZones);
 			converter.Convert();
 		}
 

--- a/BSPConvert.Lib/Source/EntityConverter.cs
+++ b/BSPConvert.Lib/Source/EntityConverter.cs
@@ -87,7 +87,7 @@ namespace BSPConvert.Lib
 		private Entities q3Entities;
 		private Entities sourceEntities;
 		private Dictionary<string, Shader> shaderDict;
-		private int minDamageToConvertTrigger;
+		private int minDamageToRespawnPlayer;
 		private bool ignoreZones;
 		private Dictionary<string, List<Entity>> entityDict = new Dictionary<string, List<Entity>>();
 		private List<Entity> removeEntities = new List<Entity>(); // Entities to remove after conversion (ex: remove weapons after converting a trigger_multiple that references target_give). TODO: It might be better to convert entities by priority, such as trigger_multiples first so that target_give weapons can be ignored after
@@ -99,12 +99,12 @@ namespace BSPConvert.Lib
 		private const string MOMENTUM_LOGIC_CASE = "_momentum_logic_case_";
 		private const int q3LipMod = 2; // Quake adds 2 units to button/door lip for some reason
 
-		public EntityConverter(Lump<Model> q3Models, Entities q3Entities, Entities sourceEntities, Dictionary<string, Shader> shaderDict, int minDamageToConvertTrigger, bool ignoreZones)
+		public EntityConverter(Lump<Model> q3Models, Entities q3Entities, Entities sourceEntities, Dictionary<string, Shader> shaderDict, int minDamageToRespawnPlayer, bool ignoreZones)
 		{
 			this.q3Entities = q3Entities;
 			this.sourceEntities = sourceEntities;
 			this.shaderDict = shaderDict;
-			this.minDamageToConvertTrigger = minDamageToConvertTrigger;
+			this.minDamageToRespawnPlayer = minDamageToRespawnPlayer;
 			this.ignoreZones = ignoreZones;
 			this.q3Models = q3Models;
 
@@ -521,13 +521,12 @@ namespace BSPConvert.Lib
 		{
 			if (int.TryParse(trigger["dmg"], out var damage))
 			{
-				if (damage >= minDamageToConvertTrigger)
-				{
-					trigger.ClassName = "trigger_teleport";
-					trigger["target"] = MOMENTUM_START_ENTITY;
-					trigger["spawnflags"] = "1";
-					trigger["velocitymode"] = "1";
-				}
+				// TODO: Remove this if we ever add health to mmdf
+				if (damage >= minDamageToRespawnPlayer)
+					trigger["damage"] = "200";
+
+				trigger["spawnflags"] = "1";
+				trigger.Remove("dmg");
 			}
 		}
 

--- a/BSPConvert.Test/BSPConverterTest.cs
+++ b/BSPConvert.Test/BSPConverterTest.cs
@@ -33,7 +33,7 @@ namespace BSPConvert.Test
 			{
 				noPak = false,
 				DisplacementPower = 4,
-				minDamageToConvertTrigger = 50,
+				minDamageToRespawnPlayer = 50,
 				ignoreZones = false,
 				oldBSP = false,
 				prefix = "df_",


### PR DESCRIPTION
Players now respawn when touching a kill trigger, so converting these to trigger_teleport is no longer needed.

We'll need to wait until the respawn on death change is added to Momentum Mod before merging this.