### PR TITLE
Bake 4x overbright directly into lightmap

### DIFF
--- a/BSPConvert.Cmd/Program.cs
+++ b/BSPConvert.Cmd/Program.cs
@@ -37,9 +37,6 @@ namespace BSPConvert.Cmd
 
 			[Option("noenvmap", Required = false, HelpText = "Disable envmap (specular cubemap) shader conversion. Useful for maps where Source's cubemap poorly emulates Quake 3's spheremap effect.")]
 			public bool NoEnvMap { get; set; }
-			
-			[Option("lightmapmin", Required = false, Default = 0.05f, HelpText = "Lightmap black-point lift in [0,1): remaps the [0,1] tonal range to [min,1], raising the darkest luxels off pure black to smooth out harsh/banded shadows (at the cost of shadow depth).")]
-			public float LightmapMinBrightness { get; set; }
 
 			[Option("clampoverbright", Required = false, HelpText = "Apply Quake 3's hue-preserving overbright clamp to lightmaps, flattening over-bright highlights toward white instead of letting the engine's 4x overbright blow past white.")]
 			public bool ClampOverbright { get; set; }
@@ -133,7 +130,6 @@ namespace BSPConvert.Cmd
 					outputDir = options.OutputDirectory,
 					mapFilter = options.Maps?.ToArray(),
 					offModeEntityFallback = options.OffModeEntityFallback,
-					lightmapMinBrightness = options.LightmapMinBrightness,
 					clampOverbright = options.ClampOverbright,
 					flipbook = new FlipbookOptions()
 					{

--- a/BSPConvert.Lib/Source/BSPConverter.cs
+++ b/BSPConvert.Lib/Source/BSPConverter.cs
@@ -55,10 +55,6 @@ namespace BSPConvert.Lib
 		// BSP's map name (without extension), case-insensitively. Null/empty converts every BSP.
 		public string[] mapFilter;
 		public string offModeEntityFallback;
-		// Lightmap black-point lift in [0,1): remaps the rendered [0,1] tonal range to [min,1], raising the
-		// darkest luxels off pure black to smooth out harsh/banded shadow gradients (at the cost of shadow
-		// depth); 0 = no change. See ColorUtil.ConvertQ3LightmapToColorRGBExp32.
-		public float lightmapMinBrightness;
 		// When set, applies Quake 3's hue-preserving overbright clamp to lightmap luxels (flattens
 		// over-bright highlights toward white). Off by default. See ColorUtil.ConvertQ3LightmapToColorRGBExp32.
 		public bool clampOverbright;
@@ -2543,7 +2539,6 @@ namespace BSPConvert.Lib
 							qLightmapData[q3LightmapOffset + index * 3 + 0],
 							qLightmapData[q3LightmapOffset + index * 3 + 1],
 							qLightmapData[q3LightmapOffset + index * 3 + 2],
-							options.lightmapMinBrightness,
 							options.clampOverbright);
 
 						lmColors.Add(color);
@@ -2625,7 +2620,6 @@ namespace BSPConvert.Lib
 							lmData.data[index * 3 + 0],
 							lmData.data[index * 3 + 1],
 							lmData.data[index * 3 + 2],
-							options.lightmapMinBrightness,
 							options.clampOverbright);
 
 						lmColors.Add(color);

--- a/BSPConvert.Lib/Source/Utilities/ColorUtil.cs
+++ b/BSPConvert.Lib/Source/Utilities/ColorUtil.cs
@@ -2,11 +2,13 @@
 {
 	public static class ColorUtil
 	{
-		// The Momentum engine re-applies a 4x overbright to lightmapped surfaces at load
-		// (map_loadhelper.cpp ColorModulate), matching Quake 3's default r_mapOverBrightBits = 2 (<<2).
+		// Quake 3 applies a 4x overbright to lightmapped surfaces at display time (R_ColorShiftLightingBytes
+		// in tr_bsp.c, with the default r_mapOverBrightBits = 2, i.e. << 2). We bake that factor directly
+		// into the stored RGBExp32 luxels (below) so the lighting is display-ready and renders identically on
+		// world geometry and brush entities.
 		private const int OVERBRIGHT = 4;
 
-		public static ColorRGBExp32 ConvertQ3LightmapToColorRGBExp32(byte r, byte g, byte b, float lightmapMin = 0f, bool clampOverbright = false)
+		public static ColorRGBExp32 ConvertQ3LightmapToColorRGBExp32(byte r, byte g, byte b, bool clampOverbright = false)
 		{
 			// The white point (brightest surviving luxel) is 255/OVERBRIGHT when the overbright clamp is
 			// active, otherwise the full 8-bit range survives; the black-point lift remaps against it.
@@ -14,11 +16,12 @@
 
 			if (clampOverbright)
 				(r, g, b) = ApplyOverbrightClamp(r, g, b);
-			(r, g, b) = ApplyMinBrightness(r, g, b, lightmapMin, ceiling);
 
-			var rf = GammaToLinear(r) * 4f; // Multiply by 4 since Source expects lightmap values in 0-4 range
-			var gf = GammaToLinear(g) * 4f;
-			var bf = GammaToLinear(b) * 4f;
+			// The * 4f maps into the 0-4 HDR range Source's lightmap format expects; the * OVERBRIGHT bakes
+			// in Quake 3's display overbright so the renderer needs no extra per-material scaling.
+			var rf = GammaToLinear(r) * 4f * OVERBRIGHT;
+			var gf = GammaToLinear(g) * 4f * OVERBRIGHT;
+			var bf = GammaToLinear(b) * 4f * OVERBRIGHT;
 
 			return PackColorRGBExp32(rf, gf, bf);
 		}
@@ -58,8 +61,8 @@
 		// Replicates the saturation behaviour of Quake 3's R_ColorShiftLightingBytes (tr_bsp.c). Q3
 		// multiplies lightmap colors by the overbright factor and, when a channel exceeds 255, scales ALL
 		// channels down together (hue-preserving) so a bright luxel flattens toward white instead of
-		// clipping per channel. Because the engine applies that overbright (x4) itself, we don't amplify
-		// here - we only enforce the matching ceiling: the brightest pre-overbright luxel that survives is
+		// clipping per channel. Because we bake that overbright (x4) into the encoded luxels (not in this
+		// clamp step), here we only enforce the matching ceiling: the brightest pre-overbright luxel that survives is
 		// 255/OVERBRIGHT (= 63), above which the engine's x4 would blow past white. Bytes at or below the
 		// ceiling (most of the map, incl. midtones) pass through unchanged, so the look there is preserved;
 		// only the over-bright luxels Q3 discards get flattened, fixing the too-bright/blotchy highlights.
@@ -75,23 +78,6 @@
 				(byte)(r * ceiling / max),
 				(byte)(g * ceiling / max),
 				(byte)(b * ceiling / max));
-		}
-
-		// Raises the lightmap black point: linearly remaps each channel's [0, ceiling] range to
-		// [min*ceiling, ceiling] (i.e. the rendered [0,1] tonal range to [min,1], white unchanged). Near-
-		// black 8-bit luxels have huge RELATIVE gaps (byte 1 vs 2 = 2x) that read as harsh banding once the
-		// overbright/display amplify them; lifting the darkest luxels to a dim floor shrinks those relative
-		// gaps for smoother shadow gradients, at the cost of shadow depth. min = 0 leaves darks untouched.
-		// ceiling is the white point (255/OVERBRIGHT with the overbright clamp, else the full 255).
-		private static (byte r, byte g, byte b) ApplyMinBrightness(byte r, byte g, byte b, float min, int ceiling)
-		{
-			if (min <= 0f)
-				return (r, g, b);
-
-			var floor = min * ceiling;
-
-			byte Remap(byte c) => (byte)(floor + (1f - min) * c);
-			return (Remap(r), Remap(g), Remap(b));
 		}
 
 		private static float GammaToLinear(float gamma)


### PR DESCRIPTION
Merge this when we are ready to release BSPConvert 1.0 and all existing maps have been re-converted.